### PR TITLE
Remove no-op dnsPolicy

### DIFF
--- a/templates/single-node.yml
+++ b/templates/single-node.yml
@@ -116,7 +116,6 @@ spec:
             - /docker/alive-check
           initialDelaySeconds: 600
           periodSeconds: 60
-      dnsPolicy: ClusterFirst
       volumes:
       - name: configmount
         configMap:


### PR DESCRIPTION
dnsPolicy defaults to ClusterFirst, no reason to specify it.

see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/