### PR TITLE
Updating timeoutSeconds for probes

### DIFF
--- a/templates/single-node.yml
+++ b/templates/single-node.yml
@@ -109,6 +109,7 @@ spec:
             - /docker/server-ready-check
           initialDelaySeconds: 360
           periodSeconds: 30
+          timeoutSeconds: 20
         livenessProbe:
           exec:
             command:
@@ -117,6 +118,7 @@ spec:
             - /docker/alive-check
           initialDelaySeconds: 600
           periodSeconds: 60
+          timeoutSeconds: 30
       dnsPolicy: ClusterFirst
       volumes:
       - name: configmount

--- a/templates/three-node.yml
+++ b/templates/three-node.yml
@@ -147,6 +147,7 @@ spec:
             - /docker/server-ready-check
           initialDelaySeconds: 360
           periodSeconds: 30
+          timeoutSeconds: 20
         livenessProbe:
           exec:
             command:
@@ -155,6 +156,7 @@ spec:
             - /docker/alive-check
           initialDelaySeconds: 600
           periodSeconds: 60
+          timeoutSeconds: 30
       volumes:
       - name: configmount
         configMap:


### PR DESCRIPTION
Updating timeoutSeconds for probes, as from v1.20 timeoutSeconds are respected by Kubernetes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes