### PR TITLE
fixed problem with TSM_REMOTE_PASSWORD

### DIFF
--- a/templates/single-node.yml
+++ b/templates/single-node.yml
@@ -92,6 +92,8 @@ spec:
           limits:
             memory: 32Gi
             cpu: 8
+        securityContext:
+          allowPrivilegeEscalation: true
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/templates/three-node.yml
+++ b/templates/three-node.yml
@@ -128,6 +128,8 @@ spec:
           limits:
             memory: 32Gi
             cpu: 8
+        securityContext:
+          allowPrivilegeEscalation: true
         ports:
         - containerPort: 8080
         volumeMounts:


### PR DESCRIPTION
Fixed an issue where the password TSM_REMOTE_PASSWORD was not assigned to the user TSM_REMOTE_USERNAME

docs: https://help.tableau.com/current/server-linux/en-us/server-in-container_image.htm TSM_REMOTE_PASSWORD is not setting if the cluster has pod security policy or kyverno/gatekeeper configured with allowPrivilegeEscalation: false

entrypoint has code:
```bash
setup_remote_user() {
    set +ex

    # If the password is not set su command should be success irrespective of password passed.
    # If su command fails, it is assumed that password is set so return from function.  
    dummy_password=""
    if ! echo "${dummy_password}" | su "${TSM_REMOTE_USERNAME}" -c true &> /dev/null ; then
        set -ex
        return
    fi
    ...
    ...
       su -l ${TSM_REMOTE_USERNAME} -c "printf \"${remote_pw}\\n\" | rpasswd"
```
If allowPrivilegeEscalation is restricted then this code just return from setup_remote_user:
```
+ setup_remote_user
+ set +ex
+ return
```